### PR TITLE
Add heartbreak healing page

### DIFF
--- a/heartbreak/README.md
+++ b/heartbreak/README.md
@@ -1,0 +1,5 @@
+# Heartbreak Healing
+
+A small interactive page to visualize healing progress and generate supportive emojis.
+
+Edit `script.js` for functionality and `styles.css` for layout/styling. Page is in `index.html`.

--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Heartbreak Healing</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="progress-wrapper">
+    <div id="progress-bar"></div>
+  </div>
+  <div id="boy-image" aria-label="healing status"></div>
+
+  <div id="buttons">
+    <button data-emoji="💪">💪 Exercise</button>
+    <button data-emoji="📝">📝 Write no-send letters</button>
+    <button data-emoji="🧠">🧠 Go to therapy (the good poly-informed one)</button>
+    <button data-emoji="🍲">🍲 Eat food</button>
+    <button data-emoji="🧑‍🤝‍🧑">🧑‍🤝‍🧑 Spend time with friends</button>
+    <button data-emoji="🤝">🤝 Get to know other new people</button>
+    <button data-emoji="👪">👪 Spend time with family</button>
+    <button data-emoji="✈️">✈️ Travel (solo?)</button>
+    <button data-emoji="📚">📚 Learn something new</button>
+    <button data-emoji="😭">😭 Cry (with sad music?) and mourn</button>
+    <button data-emoji="😴">😴 Get good sleep</button>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -1,0 +1,36 @@
+const PROGRESS = 15; // percent
+
+function updateProgress() {
+  const bar = document.getElementById('progress-bar');
+  bar.style.width = PROGRESS + '%';
+
+  const boy = document.getElementById('boy-image');
+  let emoji = '😢';
+  if (PROGRESS >= 75) emoji = '😄';
+  else if (PROGRESS >= 50) emoji = '🙂';
+  else if (PROGRESS >= 25) emoji = '😔';
+  boy.textContent = emoji;
+}
+
+function spawnEmoji(emoji) {
+  const span = document.createElement('span');
+  span.className = 'emoji';
+  span.textContent = emoji;
+  span.style.left = Math.random() * (window.innerWidth - 30) + 'px';
+  span.style.top = (window.innerHeight - 40) + 'px';
+  document.body.appendChild(span);
+  setTimeout(() => span.remove(), 3000);
+}
+
+function setupButtons() {
+  document.querySelectorAll('#buttons button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      spawnEmoji(btn.getAttribute('data-emoji'));
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  updateProgress();
+  setupButtons();
+});

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -1,0 +1,83 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #f4f4f9;
+}
+
+#progress-wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 20px;
+  background: #ddd;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+#progress-bar {
+  height: 100%;
+  width: 15%;
+  background-image: repeating-linear-gradient(
+    45deg,
+    #4caf50,
+    #4caf50 10px,
+    #43a047 10px,
+    #43a047 20px
+  );
+  background-size: 30px 30px;
+  animation: barberpole 1s linear infinite;
+}
+
+@keyframes barberpole {
+  from { background-position: 0 0; }
+  to { background-position: 30px 0; }
+}
+
+#boy-image {
+  font-size: 4rem;
+  margin-top: 40px;
+}
+
+#buttons {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  max-width: 600px;
+}
+
+#buttons button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 5px;
+  background-color: #007BFF;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+#buttons button:hover {
+  background-color: #0056b3;
+}
+
+.emoji {
+  position: fixed;
+  font-size: 2rem;
+  pointer-events: none;
+  animation: floatUp 3s ease-out forwards;
+}
+
+@keyframes floatUp {
+  from { transform: translateY(0); opacity: 1; }
+  to { transform: translateY(-150px); opacity: 0; }
+}


### PR DESCRIPTION
## Summary
- add new `heartbreak` page with healing progress bar
- animate bar with barber pole effect and show emoji boy progress
- spawn floating emojis when clicking self-care buttons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885299e315c8332a470a863bf097a67