### PR TITLE
Add heartbreak progress label

### DIFF
--- a/heartbreak/README.md
+++ b/heartbreak/README.md
@@ -1,0 +1,5 @@
+# Heartbreak Healing
+
+A small interactive page to visualize healing progress and generate supportive emojis.
+
+Edit `script.js` for functionality and `styles.css` for layout/styling. Page is in `index.html`.

--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Heartbreak Healing</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>charlie’s heartbreak progress</h1>
+  <div id="progress-wrapper">
+    <div id="progress-bar"></div>
+    <span id="progress-label" aria-live="polite"></span>
+  </div>
+  <div id="boy-image" aria-label="healing status"></div>
+  <button id="shuffle-image">How’s Charlie doing?</button>
+
+  <div id="buttons">
+    <button data-emoji="💪">💪 Exercise</button>
+    <button data-emoji="📝">📝 Write no-send letters</button>
+    <button data-emoji="🧠">🧠 Go to therapy (the good poly-informed one)</button>
+    <button data-emoji="🍲">🍲 Eat food</button>
+    <button data-emoji="🧑‍🤝‍🧑">🧑‍🤝‍🧑 Spend time with friends</button>
+    <button data-emoji="🤝">🤝 Get to know other new people</button>
+    <button data-emoji="👪">👪 Spend time with family</button>
+    <button data-emoji="✈️">✈️ Travel (solo?)</button>
+    <button data-emoji="📚">📚 Learn something new</button>
+    <button data-emoji="😭">😭 Cry (with sad music?) and mourn</button>
+    <button data-emoji="😴">😴 Get good sleep</button>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -1,0 +1,67 @@
+const PROGRESS = 15; // percent
+
+const IMAGE_BUCKETS = [
+  ['\u{1F64D}\u{FE0F}\u{200D}\u{2642}\u{FE0F}', '\u{1F62D}', '\u{1F494}'], // very depressed 0-20%
+  ['\u{1F614}', '\u{1F616}', '\u{1F61E}'], // sad 21-40%
+  ['\u{1F610}', '\u{1F642}'], // okay 41-60%
+  ['\u{1F60A}', '\u{1F603}', '\u{1F604}'], // happy 61-80%
+  ['\u{1F601}', '\u{1F60E}', '\u{1F389}']  // very happy 81-100%
+];
+
+function bucketIndex(progress) {
+  const idx = Math.min(Math.floor(progress / 20), IMAGE_BUCKETS.length - 1);
+  return idx;
+}
+
+function randomBoyImage(progress) {
+  const bucket = IMAGE_BUCKETS[bucketIndex(progress)];
+  return bucket[Math.floor(Math.random() * bucket.length)];
+}
+
+function updateProgress() {
+  const bar = document.getElementById('progress-bar');
+  bar.style.width = PROGRESS + '%';
+  const label = document.getElementById('progress-label');
+  if (label) {
+    label.textContent = `${PROGRESS}/100%`;
+  }
+  updateBoyImage();
+}
+
+function updateBoyImage() {
+  const boy = document.getElementById('boy-image');
+  const emoji = randomBoyImage(PROGRESS);
+  boy.textContent = emoji;
+  boy.setAttribute('aria-label', `progress emoji ${PROGRESS} percent`);
+}
+
+function spawnEmoji(emoji) {
+  const span = document.createElement('span');
+  span.className = 'emoji';
+  span.textContent = emoji;
+  span.style.left = Math.random() * (window.innerWidth - 30) + 'px';
+  span.style.top = (window.innerHeight - 40) + 'px';
+  document.body.appendChild(span);
+  setTimeout(() => span.remove(), 3000);
+}
+
+function setupButtons() {
+  document.querySelectorAll('#buttons button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      spawnEmoji(btn.getAttribute('data-emoji'));
+    });
+  });
+}
+
+function setupShuffle() {
+  const btn = document.getElementById('shuffle-image');
+  if (btn) {
+    btn.addEventListener('click', updateBoyImage);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  updateProgress();
+  setupButtons();
+  setupShuffle();
+});

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -1,0 +1,116 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #f4f4f9;
+}
+
+h1 {
+  margin-top: 30px;
+  margin-bottom: 10px;
+  font-size: 1.5rem;
+}
+
+#shuffle-image {
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 5px;
+  background-color: #28a745;
+  color: #fff;
+  cursor: pointer;
+}
+
+#shuffle-image:hover {
+  background-color: #1e7e34;
+}
+
+#progress-wrapper {
+  position: fixed;
+  display: block;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 20px;
+  background: #ddd;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+#progress-bar {
+  height: 100%;
+  width: 15%;
+  background-image: repeating-linear-gradient(
+    45deg,
+    #4caf50,
+    #4caf50 10px,
+    #43a047 10px,
+    #43a047 20px
+  );
+  background-size: 30px 30px;
+  animation: barberpole 1s linear infinite;
+}
+
+#progress-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  line-height: 20px;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #000;
+  pointer-events: none;
+}
+
+@keyframes barberpole {
+  from { background-position: 0 0; }
+  to { background-position: 30px 0; }
+}
+
+#boy-image {
+  font-size: 4rem;
+  margin-top: 40px;
+}
+
+#buttons {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  max-width: 600px;
+}
+
+#buttons button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 5px;
+  background-color: #007BFF;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+#buttons button:hover {
+  background-color: #0056b3;
+}
+
+.emoji {
+  position: fixed;
+  font-size: 2rem;
+  pointer-events: none;
+  animation: floatUp 3s ease-out forwards;
+}
+
+@keyframes floatUp {
+  from { transform: translateY(0); opacity: 1; }
+  to { transform: translateY(-150px); opacity: 0; }
+}


### PR DESCRIPTION
## Summary
- display a progress label on the heartbreak page
- update shuffle logic with accessible emoji labels
- style progress label overlay

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885299e315c8332a470a863bf097a67