### PR TITLE
Enable GitHub Pages previews

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,28 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - uses: actions/deploy-pages@v1
+        with:
+          preview: ${{ github.event_name == 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
+# cfireborn.github.io
 
-Read me!
-- git status
-- git add .
-- git commit -m "descriptive message"
-- git push
+This repository hosts a collection of small web games and demos.
+All pages are static and can be opened directly in a browser.
+
+## Development
+
+Simply edit the files in place and open `index.html` or any of the
+subfolders' `index.html` in a browser to test locally.
+
+## Previewing Pull Requests
+
+A GitHub Actions workflow automatically deploys previews for every pull
+request. Once you open a PR, the "Deploy static site to GitHub Pages"
+check will provide a URL where you can view the proposed changes.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy the site for pushes and PRs
- document how PR previews work

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68852f1190208332876b659e1daeffac