### PR TITLE
Add progress label to heartbreak progress bar

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -9,6 +9,7 @@
 <body>
   <div id="progress-wrapper">
     <div id="progress-bar"></div>
+    <div id="progress-label"></div>
   </div>
   <div id="boy-image" aria-label="healing status"></div>
 

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -4,6 +4,9 @@ function updateProgress() {
   const bar = document.getElementById('progress-bar');
   bar.style.width = PROGRESS + '%';
 
+  const label = document.getElementById('progress-label');
+  label.textContent = PROGRESS + '/100%';
+
   const boy = document.getElementById('boy-image');
   let emoji = '😢';
   if (PROGRESS >= 75) emoji = '😄';

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -23,6 +23,19 @@ body {
   overflow: hidden;
 }
 
+#progress-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  pointer-events: none;
+}
+
 #progress-bar {
   height: 100%;
   width: 15%;


### PR DESCRIPTION
## Summary
- display a progress label on the heartbreak healing progress bar
- style the progress label

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68854141ebf08332b1dcc8a4f0be0962