### PR TITLE
Add activity log demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 This repository hosts a collection of small web games and demos.
 All pages are static and can be opened directly in a browser.
 
+### Activity Log
+
+The `activitylog` directory contains a small demo that records
+clicked actions with random creative blurbs. Open `activitylog/index.html`
+in a browser to try it out.
+
 ## Development
 
 Simply edit the files in place and open `index.html` or any of the

--- a/activitylog/index.html
+++ b/activitylog/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Activity Log</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 20px;
+    }
+    #actions button {
+      margin: 4px;
+    }
+    #log {
+      max-height: 300px;
+      overflow-y: auto;
+      border: 1px solid #ccc;
+      padding: 10px;
+      margin-top: 20px;
+    }
+    .entry {
+      margin-bottom: 10px;
+      padding-bottom: 10px;
+      border-bottom: 1px dashed #aaa;
+    }
+  </style>
+</head>
+<body>
+  <h1>Activity Log</h1>
+  <div id="actions">
+    <button data-action="exercise">Exercise</button>
+    <button data-action="eat">Eat Food</button>
+    <button data-action="work">Work</button>
+    <button data-action="play">Play Games</button>
+    <button data-action="read">Read Books</button>
+    <button data-action="meditate">Meditate</button>
+    <button data-action="shop">Shop</button>
+    <button data-action="cook">Cook</button>
+    <button data-action="travel">Travel</button>
+    <button data-action="sleep">Sleep</button>
+  </div>
+
+  <div id="log"></div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/activitylog/script.js
+++ b/activitylog/script.js
@@ -1,0 +1,69 @@
+const blurbs = {
+  exercise: [
+    "Feels good, nice rock climb with new climbing partners.",
+    "Sweaty session at the gym, but the endorphins pay off.",
+    "A quick yoga flow to stretch out the morning."
+  ],
+  eat: [
+    "Tasty ramen, good self-date.",
+    "Polished off a colorful salad bursting with flavor.",
+    "Indulged in decadent chocolate cake - no regrets."
+  ],
+  work: [
+    "Knocked out tasks like a productivity ninja.",
+    "Another meeting survived, coffee in hand.",
+    "Turned ideas into progress with a flurry of keystrokes."
+  ],
+  play: [
+    "Beat that tricky boss at last!",
+    "Caught up with friends for a board game night.",
+    "Lost track of time exploring a pixelated world."
+  ],
+  read: [
+    "Got lost in a fantasy realm for a chapter or two.",
+    "Devoured some non-fiction knowledge nuggets.",
+    "Comic book binge for the win!"
+  ],
+  meditate: [
+    "Silence and breathing brought surprising clarity.",
+    "Took a mindful pause and felt tension melt.",
+    "Zen mode achieved; the world slowed down."
+  ],
+  shop: [
+    "Found a bargain that sparked pure joy.",
+    "Window-shopped with no regrets.",
+    "Scored the last item on the shelf—victory!"
+  ],
+  cook: [
+    "Experimented with spices and nailed it.",
+    "Whipped up comfort food that warmed the soul.",
+    "Burned the first batch, aced the second."
+  ],
+  travel: [
+    "Imaginary road trip turned daydream into wanderlust.",
+    "Took the scenic route and found new inspiration.",
+    "Photos snapped, memories made."
+  ],
+  sleep: [
+    "Power nap gave a burst of renewed energy.",
+    "Dreamland was a wild adventure all its own.",
+    "Early bedtime? Best decision of the day."
+  ]
+};
+
+function addEntry(action) {
+  const messages = blurbs[action];
+  const message = messages[Math.floor(Math.random() * messages.length)];
+  const log = document.getElementById('log');
+  const div = document.createElement('div');
+  div.className = 'entry';
+  const now = new Date().toLocaleTimeString();
+  div.textContent = `[${now}] ${action}: ${message}`;
+  log.insertBefore(div, log.firstChild);
+}
+
+document.getElementById('actions').addEventListener('click', (e) => {
+  if (e.target.matches('button[data-action]')) {
+    addEntry(e.target.getAttribute('data-action'));
+  }
+});


### PR DESCRIPTION
## Summary
- add interactive `activitylog` demo with creative blurbs
- document new feature in the README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688549ec293c833287d0f4c5d21c5895