### PR TITLE
Swap svg images from buckets

### DIFF
--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -63,23 +63,23 @@ function updateCharlieImage() {
 }
 
 function shuffleCharlie() {
-  // Get a new random image for the current healing stage
-  if (typeof getRandomImagePath === 'function') {
-    const newImagePath = getRandomImagePath(PROGRESS);
+  // Get the next image in the same stage/style bucket
+  if (typeof getNextImageInBucket === 'function') {
+    const nextImagePath = getNextImageInBucket(PROGRESS);
     const boyImg = document.getElementById('boy-image');
     
     // Add a subtle animation during shuffle
     boyImg.style.opacity = '0.5';
     
     setTimeout(() => {
-      boyImg.src = newImagePath;
-      currentImagePath = newImagePath;
+      boyImg.src = nextImagePath;
+      currentImagePath = nextImagePath;
       boyImg.style.opacity = '1';
       
       // Log the stage info for debugging
       if (typeof getStageInfo === 'function') {
         const stageInfo = getStageInfo(PROGRESS);
-        console.log(`Shuffled to new ${stageInfo.name} stage image: ${newImagePath}`);
+        console.log(`Shuffled to next ${stageInfo.name} stage image: ${nextImagePath}`);
       }
     }, 150);
   }


### PR DESCRIPTION
Modify the 'shuffle Charlie' button to cycle through images within the same stage and art style bucket, and correct image file extensions to SVG.

---

[Open in Web](https://cursor.com/agents?id=bc-af736263-2920-49b5-aaec-dd15c64b1fa0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-af736263-2920-49b5-aaec-dd15c64b1fa0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)