### PR TITLE
Log preview URL

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
-      - uses: actions/deploy-pages@v4
+      - id: deploy
+        uses: actions/deploy-pages@v4
         with:
           preview: ${{ github.event_name == 'pull_request' }}
+      - name: Log preview URL
+        if: github.event_name == 'pull_request'
+        run: echo "Preview URL: ${{ steps.deploy.outputs.page_url }}"

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ subfolders' `index.html` in a browser to test locally.
 A GitHub Actions workflow automatically deploys previews for every pull
 request. Once you open a PR, the "Deploy static site to GitHub Pages"
 check will provide a URL where you can view the proposed changes.
+The build logs also print this preview URL after deployment for quick access.


### PR DESCRIPTION
## Summary
- log preview URL for PR builds
- document that the preview URL is printed in the logs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68855253df5c83329595867020f6d202