### PR TITLE
Update heartbreak days-since calculation

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <h1 id="title">Charlie's Heartbreak Healing Progress</h1>
-  <p id="project-blurb">Charlie broke up with his partner on July 11, <span id="days-since"></span> days ago. Track how he's doing by checking in on this page. Press buttons to suggest what he should do to keep on healing. Look at images highly representative of his current mood and state. Text him how to improve this project.</p>
+  <p id="project-blurb">Charlie broke up with his partner on July 11, 2025, <span id="days-since"></span> days ago. Track how he's doing by checking in on this page. Press buttons to suggest what he should do to keep on healing. Look at images highly representative of his current mood and state. Text him how to improve this project.</p>
   <div id="progress-wrapper">
     <div id="progress-bar"></div>
     <div id="progress-label"></div>

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -1,7 +1,8 @@
 const PROGRESS = 15; // percent
 
 let currentImagePath = '';
-const breakupDate = new Date('2023-07-11');
+// July 11, 2025 at midnight UTC
+const breakupDate = new Date('2025-07-11T00:00:00Z');
 
 function updateDaysSinceBreakup() {
   const span = document.getElementById('days-since');


### PR DESCRIPTION
## Summary
- calculate days since July 11, 2025 at runtime
- show the year in the blurb

## Testing
- `date -u`

------
https://chatgpt.com/codex/tasks/task_e_6885563e3a30833297e9dc862d58b5f2