### PR TITLE
Add progress adjustment buttons

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -13,6 +13,10 @@
     <div id="progress-bar"></div>
     <div id="progress-label"></div>
   </div>
+  <div id="progress-controls">
+    <button id="decrease-progress" aria-label="Decrease progress">-5%</button>
+    <button id="increase-progress" aria-label="Increase progress">+5%</button>
+  </div>
   
   <div id="boy-container">
     <img id="boy-image" src="" alt="Charlie's healing journey" aria-label="healing status">

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -1,4 +1,4 @@
-const PROGRESS = 15; // percent
+let progress = 15; // percent
 
 let currentImagePath = '';
 // July 11, 2025 at midnight UTC
@@ -14,13 +14,18 @@ function updateDaysSinceBreakup() {
 
 function updateProgress() {
   const bar = document.getElementById('progress-bar');
-  bar.style.width = PROGRESS + '%';
+  bar.style.width = progress + '%';
 
   const label = document.getElementById('progress-label');
-  label.textContent = PROGRESS + '/100%';
+  label.textContent = progress + '/100%';
 
   // Update Charlie's image based on healing progress
   updateCharlieImage();
+}
+
+function changeProgress(delta) {
+  progress = Math.min(100, Math.max(0, progress + delta));
+  updateProgress();
 }
 
 function updateCharlieImage() {
@@ -28,7 +33,7 @@ function updateCharlieImage() {
   
   // Use the image randomizer to get appropriate image
   if (typeof getRandomImagePath === 'function') {
-    currentImagePath = getRandomImagePath(PROGRESS);
+    currentImagePath = getRandomImagePath(progress);
     boyImg.src = currentImagePath;
     
     // Add error handling for missing images
@@ -40,9 +45,9 @@ function updateCharlieImage() {
       fallback.style.fontSize = '4rem';
       
       let emoji = '😢';
-      if (PROGRESS >= 75) emoji = '😄';
-      else if (PROGRESS >= 50) emoji = '🙂';
-      else if (PROGRESS >= 25) emoji = '😔';
+      if (progress >= 75) emoji = '😄';
+      else if (progress >= 50) emoji = '🙂';
+      else if (progress >= 25) emoji = '😔';
       fallback.textContent = emoji;
       
       this.parentNode.insertBefore(fallback, this);
@@ -60,9 +65,9 @@ function updateCharlieImage() {
     // Fallback to emoji system if randomizer not available
     boyImg.style.display = 'none';
     let emoji = '😢';
-    if (PROGRESS >= 75) emoji = '😄';
-    else if (PROGRESS >= 50) emoji = '🙂';
-    else if (PROGRESS >= 25) emoji = '😔';
+    if (progress >= 75) emoji = '😄';
+    else if (progress >= 50) emoji = '🙂';
+    else if (progress >= 25) emoji = '😔';
     
     const fallback = document.createElement('div');
     fallback.id = 'boy-emoji-fallback';
@@ -75,7 +80,7 @@ function updateCharlieImage() {
 function shuffleCharlie() {
   // Get the next image in the same stage/style bucket
   if (typeof getNextImageInBucket === 'function') {
-    const nextImagePath = getNextImageInBucket(PROGRESS);
+    const nextImagePath = getNextImageInBucket(progress);
     const boyImg = document.getElementById('boy-image');
     
     // Add a subtle animation during shuffle
@@ -88,7 +93,7 @@ function shuffleCharlie() {
       
       // Log the stage info for debugging
       if (typeof getStageInfo === 'function') {
-        const stageInfo = getStageInfo(PROGRESS);
+        const stageInfo = getStageInfo(progress);
         console.log(`Shuffled to next ${stageInfo.name} stage image: ${nextImagePath}`);
       }
     }, 150);
@@ -194,11 +199,20 @@ function setupButtons() {
       addEntry(btn.getAttribute('data-action'));
     });
   });
-  
+
   // Setup shuffle Charlie button
   const shuffleBtn = document.getElementById('shuffle-charlie');
   if (shuffleBtn) {
     shuffleBtn.addEventListener('click', shuffleCharlie);
+  }
+
+  const increaseBtn = document.getElementById('increase-progress');
+  const decreaseBtn = document.getElementById('decrease-progress');
+  if (increaseBtn) {
+    increaseBtn.addEventListener('click', () => changeProgress(5));
+  }
+  if (decreaseBtn) {
+    decreaseBtn.addEventListener('click', () => changeProgress(-5));
   }
 }
 

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -65,6 +65,30 @@ h1#title {
   animation: barberpole 1s linear infinite;
 }
 
+#progress-controls {
+  position: fixed;
+  top: 25px;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+#progress-controls button {
+  padding: 0.2rem 0.6rem;
+  border: none;
+  border-radius: 5px;
+  background-color: #6c757d;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+#progress-controls button:hover {
+  background-color: #5a6268;
+}
+
 @keyframes barberpole {
   from { background-position: 0 0; }
   to { background-position: 30px 0; }


### PR DESCRIPTION
## Summary
- add decrease/increase buttons to adjust progress
- allow progress change in script.js
- style new progress control buttons

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885581aaab88332aa5df719e3207134