### PR TITLE
Fix YAML syntax in GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,4 +31,4 @@ jobs:
           preview: ${{ github.event_name == 'pull_request' }}
       - name: Log preview URL
         if: github.event_name == 'pull_request'
-        run: echo "Preview URL: ${{ steps.deploy.outputs.page_url }}"
+        run: "echo \"Preview URL: ${{ steps.deploy.outputs.page_url }}\""


### PR DESCRIPTION
## Summary
- fix quoting on the `run` command inside `.github/workflows/pages.yml`

## Testing
- `python3 - <<'EOF'
import yaml, glob
for f in glob.glob('**/*.yml', recursive=True):
    with open(f) as fh:
        yaml.safe_load(fh)
print('YAML okay')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688559b02db88332953e5f20b1491fe4