### PR TITLE
Add preview pages workflow

### DIFF
--- a/.github/workflows/preview-pages.yml
+++ b/.github/workflows/preview-pages.yml
@@ -1,0 +1,37 @@
+name: Preview Pages for PRs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  pull-requests: write
+  contents: write
+
+concurrency:
+  group: preview-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy preview
+        id: preview
+        uses: rajyan/preview-pages@v1
+        with:
+          source-dir: .
+          git-config-name: cfireborn
+          git-config-email: cfireborn@users.noreply.github.com
+          target-repository: cfireborn/cfireborn.github.io
+          target-branch: gh-pages
+          target-dir: preview-pages
+
+      - name: Log preview URL
+        run: |
+          echo "Preview URL: https://${{ steps.preview.outputs.pages-url }}"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ subfolders' `index.html` in a browser to test locally.
 
 ## Previewing Pull Requests
 
-A GitHub Actions workflow automatically deploys previews for every pull
-request. Once you open a PR, the "Deploy static site to GitHub Pages"
-check will provide a URL where you can view the proposed changes.
-The build logs also print this preview URL after deployment for quick access.
+This repository uses the [preview-pages](https://github.com/rajyan/preview-pages)
+action to automatically deploy a preview of each pull request. A comment with
+the preview link is added to the PR and the workflow logs print the same URL.
+Previews are hosted under
+`https://cfireborn.github.io/preview-pages/pr-<number>/` so you can review the
+changes before merging.


### PR DESCRIPTION
## Summary
- document preview workflow in README
- add `preview-pages` action workflow to deploy PR previews

## Testing
- `yamllint .github/workflows/preview-pages.yml`

------
https://chatgpt.com/codex/tasks/task_e_68855c4b8fd48332871680edcfd7c6ae