### PR TITLE
Add progress stage markers

### DIFF
--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -216,8 +216,35 @@ function setupButtons() {
   }
 }
 
+function createProgressMarkers() {
+  if (typeof HEALING_STAGES === 'undefined') return;
+
+  const wrapper = document.getElementById('progress-wrapper');
+  if (!wrapper) return;
+
+  const container = document.createElement('div');
+  container.id = 'progress-markers';
+  wrapper.appendChild(container);
+
+  HEALING_STAGES.forEach(stage => {
+    const marker = document.createElement('div');
+    marker.className = 'marker';
+    marker.style.left = stage.minHealing + '%';
+
+    const line = document.createElement('div');
+    line.className = 'line';
+    const label = document.createElement('span');
+    label.textContent = stage.name;
+
+    marker.appendChild(line);
+    marker.appendChild(label);
+    container.appendChild(marker);
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   updateProgress();
   updateDaysSinceBreakup();
   setupButtons();
+  createProgressMarkers();
 });

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -67,7 +67,7 @@ h1#title {
 
 #progress-controls {
   position: fixed;
-  top: 25px;
+  top: 50px;
   left: 0;
   width: 100%;
   display: flex;
@@ -87,6 +87,34 @@ h1#title {
 
 #progress-controls button:hover {
   background-color: #5a6268;
+}
+
+#progress-markers {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  margin-top: 4px;
+  height: 20px;
+  pointer-events: none;
+}
+
+#progress-markers .marker {
+  position: absolute;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.6rem;
+  color: #333;
+  white-space: nowrap;
+}
+
+#progress-markers .marker .line {
+  width: 1px;
+  height: 6px;
+  background: #333;
+  margin-bottom: 2px;
 }
 
 @keyframes barberpole {


### PR DESCRIPTION
## Summary
- tweak progress controls top margin for space
- add progress marker lines along heartbreak progress bar
- generate markers from `HEALING_STAGES` data

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885604afa7483328640d013810a299b