### PR TITLE
Adjust progress bar position

### DIFF
--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -30,7 +30,7 @@ h1#title {
 
 #progress-wrapper {
   position: fixed;
-  top: 0;
+  top: 65px;
   left: 0;
   width: 100%;
   height: 20px;


### PR DESCRIPTION
## Summary
- reposition the progress bar so it's below the mood markers

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_688b025354d48332baa2a6096e78f51c