### PR TITLE
Update heartbreak progress and add pulsing note

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -4,9 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Heartbreak Healing</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <div id="flavor-note">NEW: wrote important no-send letter on a plane and did some intense breakthwork. And a therapy worksheet. 15%->50%. From Anger to Depression! Yay! I'm depressed</div>
   <h1 id="title">Charlie's Heartbreak Healing Progress</h1>
   <p id="project-blurb">Charlie broke up with his partner on July 11, 2025, <span id="days-since"></span> days ago. Track how he's doing by checking in on this page. Press buttons to suggest what he should do to keep on healing. Look at images highly representative of his current mood and state. Text him how to improve this project.</p>
   <div id="progress-wrapper">

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -1,4 +1,5 @@
-let progress = 15; // percent
+// Starting healing progress percentage
+let progress = 50; // percent
 
 let currentImagePath = '';
 // July 11, 2025 at midnight UTC

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -11,6 +11,7 @@ body {
   flex-direction: column;
   align-items: center;
   background-color: #f4f4f9;
+  position: relative;
 }
 
 h1#title {
@@ -72,7 +73,7 @@ h1#title {
 
 #progress-bar {
   height: 100%;
-  width: 15%;
+  width: 50%;
   background-image: repeating-linear-gradient(
     45deg,
     #4caf50,
@@ -192,6 +193,24 @@ h1#title {
 @keyframes floatUp {
   from { transform: translateY(0); opacity: 1; }
   to { transform: translateY(-150px); opacity: 0; }
+}
+
+@keyframes pulseSize {
+  0%, 100% { font-size: 0.75rem; }
+  50% { font-size: 0.95rem; }
+}
+
+#flavor-note {
+  position: absolute;
+  top: calc(100vh / 6);
+  left: 50%;
+  transform: translateX(-50%) rotate(-10deg);
+  color: yellow;
+  font-family: 'Press Start 2P', cursive;
+  animation: pulseSize 3s ease-in-out infinite;
+  text-shadow: 2px 2px 2px black;
+  pointer-events: none;
+  z-index: 1000;
 }
 
 #log {


### PR DESCRIPTION
## Summary
- set initial heartbreak progress to 50%
- style progress bar to start at 50%
- include pixelated pulsing note overlay
- load a pixel font for the note
- position note a sixth of the page down with a black shadow

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b01af3efc83329cf4fbaa87b2ac0e