### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,58 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-	<script type="text/javascript" src="phaser.min.js"></script>
-    <script type="text/javascript" src="game.js"></script>
-    <link rel='icon' href='favicon.ico' type='image/x-icon'/ >
-    <title>Game</title>
+  <meta charset="UTF-8">
+  <title>Game</title>
+  <link rel="icon" href="favicon.ico" type="image/x-icon"/>
+  <script type="text/javascript" src="phaser.min.js"></script>
+  <script type="text/javascript" src="game.js"></script>
+  <style>
+    body {
+      margin: 0;
+      font-family: sans-serif;
+      background: #ffffff;
+      color: #000000;
+    }
+    body.dark {
+      background: #111111;
+      color: #eeeeee;
+    }
+    #mode-toggle {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      padding: 6px 8px;
+      border: none;
+      border-radius: 4px;
+      font-size: 16px;
+      cursor: pointer;
+      background: #eeeeee;
+      color: #000000;
+    }
+    body.dark #mode-toggle {
+      background: #333333;
+      color: #ffffff;
+    }
+  </style>
 </head>
 <body>
-    <h1>StarDodge</h1>
+  <button id="mode-toggle"></button>
+  <h1>StarDodge</h1>
+  <script>
+    const toggle = document.getElementById('mode-toggle');
+    function setButtonIcon() {
+      toggle.textContent = document.body.classList.contains('dark') ? '☀️' : '🌙';
+    }
+    function toggleMode() {
+      document.body.classList.toggle('dark');
+      localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+      setButtonIcon();
+    }
+    toggle.addEventListener('click', toggleMode);
+    if (localStorage.getItem('theme') === 'dark') {
+      document.body.classList.add('dark');
+    }
+    setButtonIcon();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dark mode toggle button on the main page
- store preference in localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b13511134833291cb33728bf0f19b