### PR TITLE
Add dark mode to heartbreak only

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <button id="mode-toggle" aria-label="Toggle dark mode">💡</button>
   <div id="flavor-note">NEW: wrote important no-send letter on a plane and did some intense breakthwork. And a therapy worksheet. 15%->50%. From Anger to Depression! Yay! I'm depressed</div>
   <h1 id="title">Charlie's Heartbreak Healing Progress</h1>
   <p id="project-blurb">Charlie broke up with his partner on July 11, 2025, <span id="days-since"></span> days ago. Track how he's doing by checking in on this page. Press buttons to suggest what he should do to keep on healing. Look at images highly representative of his current mood and state. Text him how to improve this project.</p>

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -218,8 +218,33 @@ function setupButtons() {
   }
 }
 
+function setModeIcon() {
+  const btn = document.getElementById('mode-toggle');
+  if (btn) {
+    btn.textContent = '💡';
+  }
+}
+
+function toggleDarkMode() {
+  document.body.classList.toggle('dark');
+  localStorage.setItem('hb-theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+  setModeIcon();
+}
+
+function initDarkMode() {
+  if (localStorage.getItem('hb-theme') === 'dark') {
+    document.body.classList.add('dark');
+  }
+  setModeIcon();
+  const btn = document.getElementById('mode-toggle');
+  if (btn) {
+    btn.addEventListener('click', toggleDarkMode);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   updateProgress();
   updateDaysSinceBreakup();
   setupButtons();
+  initDarkMode();
 });

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -11,7 +11,64 @@ body {
   flex-direction: column;
   align-items: center;
   background-color: #f4f4f9;
+  color: #000;
   position: relative;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+body.dark {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+#mode-toggle {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 4px;
+  background: #eeeeee;
+  color: #000;
+  cursor: pointer;
+}
+
+body.dark #mode-toggle {
+  background: #333;
+  color: #fff;
+}
+
+body.dark #project-blurb {
+  color: #ccc;
+}
+
+body.dark #progress-wrapper {
+  background: #333;
+}
+
+body.dark #progress-controls button {
+  background-color: #444;
+  color: #f4f4f9;
+}
+
+body.dark #progress-controls button:hover {
+  background-color: #555;
+}
+
+body.dark #buttons button {
+  background-color: #0056b3;
+}
+
+body.dark #buttons button:hover {
+  background-color: #004494;
+}
+
+body.dark #log {
+  border-color: #555;
+}
+
+body.dark .entry {
+  border-bottom-color: #666;
 }
 
 h1#title {


### PR DESCRIPTION
## Summary
- add lightbulb icon to Heartbreak's dark mode toggle
- expand dark mode styles for page background, text, and buttons
- simplify dark mode icon logic in script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b13511134833291cb33728bf0f19b