### PR TITLE
feat: collapse and restyle patch notes

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -68,9 +68,15 @@
     <div id="log" aria-live="polite"></div>
     <script src="script.js"></script>
 
-    <div id="patch-notes">
-      <h2>Patch Notes</h2>
+    <details id="patch-notes">
+      <summary>Patch Notes</summary>
       <ul>
+        <li>
+          Patch notes <strong>1.1.6</strong> - switched patch notes header to the default sans-serif font.
+        </li>
+        <li>
+          Patch notes <strong>1.1.5</strong> - softened patch notes styling, added spacing, and collapsed notes into a dropdown.
+        </li>
         <li>
           Patch notes <strong>1.1.4</strong> - added patch notes.
         </li>
@@ -147,6 +153,6 @@
           framework without information.
         </li>
       </ul>
-    </div>
+    </details>
   </body>
 </html>

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -286,3 +286,22 @@ h1#title {
   border-bottom: 1px dashed #aaa;
   font-size: 0.9rem;
 }
+
+#patch-notes {
+  margin-top: 2rem;
+  width: 100%;
+  max-width: 600px;
+  font-size: 0.7rem;
+  color: #777;
+}
+
+#patch-notes summary {
+  font-size: 0.8rem;
+  color: #777;
+  cursor: pointer;
+}
+
+body.dark #patch-notes,
+body.dark #patch-notes summary {
+  color: #ccc;
+}


### PR DESCRIPTION
## Summary
- hide patch notes in a dropdown with grey, smaller text matching page style
- ensure patch notes header uses default sans-serif font and log v1.1.6 entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68965f8c9fec83328f86fd8960f62433