### PR TITLE
Add shared activity log backend scaffolding

### DIFF
--- a/heartbreak/README.md
+++ b/heartbreak/README.md
@@ -5,3 +5,46 @@ Click any action button to spawn an encouraging emoji, add a note to the activit
 Use the shuffle button to see Charlie drawn in a different art style while staying in the same emotional stage.
 
 Edit `script.js` for functionality and `styles.css` for layout/styling. Page is in `index.html`.
+
+## Collective Activity Log
+
+The page can sync its activity log across visitors using a lightweight
+Express backend found in `backend/`.
+
+### Backend Setup
+
+1. Navigate to the backend folder:
+   ```bash
+   cd heartbreak/backend
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Provide a Postgres connection string in the `DATABASE_URL` environment
+   variable. Render's free PostgreSQL works well:
+   - Render dashboard → **New** → **PostgreSQL** → choose the *Free* plan.
+   - After the database is created, copy the **External Database URL** and
+     set it as `DATABASE_URL` in your environment.
+4. Start the server (defaults to port 4000):
+   ```bash
+   npm start
+   ```
+5. The server exposes:
+   - `POST /log` – store an event. IP, timestamp, and rough location are
+     automatically appended.
+   - `GET /logs` – retrieve all stored events.
+
+Front‑end code in `script.js` posts new entries to the backend and polls
+`/logs` every few seconds to keep the log synced across clients. Update the
+`LOG_SERVER` constant in `script.js` if the backend runs on a different URL.
+
+#### Deploying on Render
+
+1. Commit this repository and push it to a GitHub repo.
+2. In Render, create a **Web Service** for `heartbreak/backend` with build
+   command `npm install` and start command `npm start`.
+3. Add the `DATABASE_URL` environment variable to the service using the
+   external connection string from the database you created earlier.
+4. Deploy the service and use the generated URL as `LOG_SERVER` in the
+   client.

--- a/heartbreak/backend/index.js
+++ b/heartbreak/backend/index.js
@@ -1,0 +1,92 @@
+const express = require('express');
+const { Pool } = require('pg');
+
+const app = express();
+const PORT = process.env.PORT || 4000;
+
+// Connect to Postgres using DATABASE_URL. Render provides this env var
+// automatically when a database is linked. SSL is required for external
+// connections.
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.DATABASE_URL ? { rejectUnauthorized: false } : false
+});
+
+app.use(express.json());
+
+async function ensureTable() {
+  await pool.query(`CREATE TABLE IF NOT EXISTS logs (
+    id SERIAL PRIMARY KEY,
+    ip TEXT,
+    timestamp TIMESTAMPTZ,
+    event TEXT,
+    country TEXT,
+    region TEXT,
+    city TEXT
+  )`);
+}
+
+app.get('/logs', async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT ip, timestamp, event, country, region, city FROM logs ORDER BY id ASC');
+    const logs = rows.map(r => ({
+      ip: r.ip,
+      timestamp: r.timestamp,
+      event: r.event,
+      location: { country: r.country, region: r.region, city: r.city }
+    }));
+    res.json(logs);
+  } catch (err) {
+    console.error('Failed to read logs', err);
+    res.status(500).json({ error: 'failed to read logs' });
+  }
+});
+
+app.post('/log', async (req, res) => {
+  const event = req.body.event || '';
+  const ip = (req.headers['x-forwarded-for'] || req.socket.remoteAddress || '').split(',')[0].trim();
+  let country = null, region = null, city = null;
+
+  try {
+    const geoRes = await fetch(`https://ipapi.co/${ip}/json/`);
+    if (geoRes.ok) {
+      const geo = await geoRes.json();
+      country = geo.country_name;
+      region = geo.region;
+      city = geo.city;
+    }
+  } catch (err) {
+    console.error('Geo lookup failed', err);
+  }
+
+  const timestamp = new Date();
+
+  try {
+    const { rows } = await pool.query(
+      'INSERT INTO logs (ip, timestamp, event, country, region, city) VALUES ($1, $2, $3, $4, $5, $6) RETURNING ip, timestamp, event, country, region, city',
+      [ip, timestamp, event, country, region, city]
+    );
+    const row = rows[0];
+    res.status(201).json({
+      ip: row.ip,
+      timestamp: row.timestamp,
+      event: row.event,
+      location: { country: row.country, region: row.region, city: row.city }
+    });
+  } catch (err) {
+    console.error('Failed to store log', err);
+    res.status(500).json({ error: 'failed to store log' });
+  }
+});
+
+ensureTable()
+  .then(() => {
+    app.listen(PORT, () => {
+      console.log(`Log server running on port ${PORT}`);
+    });
+  })
+  .catch(err => {
+    console.error('Failed to start server', err);
+    process.exit(1);
+  });
+

--- a/heartbreak/backend/package.json
+++ b/heartbreak/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "heartbreak-log-server",
+  "version": "0.1.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node -e \"console.log('no tests specified')\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.3"
+  }
+}


### PR DESCRIPTION
## Summary
- persist log events in a shared PostgreSQL database through an Express backend
- document local setup and Render deployment steps for the log server

## Testing
- `npm test --prefix heartbreak/backend`
- `node --check heartbreak/script.js`
- `node --check heartbreak/backend/index.js`


------
https://chatgpt.com/codex/tasks/task_e_6896de482b888332a65b43cf1449cc2c