### PR TITLE
Use Render log server for activity sync

### DIFF
--- a/heartbreak/README.md
+++ b/heartbreak/README.md
@@ -36,8 +36,10 @@ Express backend found in `backend/`.
    - `GET /logs` – retrieve all stored events.
 
 Front‑end code in `script.js` posts new entries to the backend and polls
-`/logs` every few seconds to keep the log synced across clients. Update the
-`LOG_SERVER` constant in `script.js` if the backend runs on a different URL.
+`/logs` every few seconds to keep the log synced across clients. By default,
+`LOG_SERVER` points to the deployed Render instance at
+`https://cfireborn-github-io.onrender.com`; update this constant if your
+backend uses a different URL.
 
 #### Deploying on Render
 

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -6,7 +6,7 @@ let currentImagePath = '';
 const breakupDate = new Date('2025-07-11T00:00:00Z');
 
 // Backend endpoint for syncing activity logs
-const LOG_SERVER = 'http://localhost:4000';
+const LOG_SERVER = 'https://cfireborn-github-io.onrender.com';
 
 function updateDaysSinceBreakup() {
   const span = document.getElementById('days-since');


### PR DESCRIPTION
## Summary
- Point Heartbreak activity log to `https://cfireborn-github-io.onrender.com`
- Document Render log server URL in Heartbreak README

## Testing
- `cd heartbreak/backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896e86f205c833299f6e947de63fd9b