### PR TITLE
Record setback to 35% and retire old flavor text

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <button id="mode-toggle" aria-label="Toggle dark mode">💡</button>
-  <div id="flavor-note">NEW: wrote important no-send letter on a plane and did some intense breakthwork. And a therapy worksheet. 15%->50%. From Anger to Depression! Yay! I'm depressed</div>
+  <div id="flavor-note">NEW Aug 9: week of vacation and family reunion brought up a lot of old fond memories and I took some steps back 50->35% my therapist says grief is not a linear process which SUCKS</div>
   <h1 id="title">Charlie's Heartbreak Healing Progress</h1>
   <p id="project-blurb">Charlie broke up with his partner on July 11, 2025, <span id="days-since"></span> days ago. Track how he's doing by checking in on this page. Press buttons to suggest what he should do to keep on healing. Look at images highly representative of his current mood and state. Text him how to improve this project.</p>
   <div id="progress-wrapper">
@@ -71,6 +71,12 @@
     <details id="patch-notes">
       <summary>Patch Notes</summary>
       <ul>
+        <li>
+          Patch notes <strong>1.3.0</strong> - setback to 35%. Added synced logs for Charlie’s supporters.
+        </li>
+        <li>
+          Patch notes <strong>1.2.latest</strong> - retired flavor text “NEW: wrote important no-send letter on a plane and did some intense breakthwork. And a therapy worksheet. 15%->50%. From Anger to Depression! Yay! I'm depressed”
+        </li>
         <li>
           Patch notes <strong>1.1.6</strong> - switched patch notes header to the default sans-serif font.
         </li>

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -1,5 +1,5 @@
 // Starting healing progress percentage
-let progress = 50; // percent
+let progress = 35; // percent
 
 let currentImagePath = '';
 // July 11, 2025 at midnight UTC


### PR DESCRIPTION
## Summary
- Set default heartbreak progress to 35%
- Note setback and synced logs in new patch notes and retire old flavor text
- Update flavor text with Aug 9 vacation reflections

## Testing
- `cd heartbreak/backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896eb57e6e483328923254ccf2ced32