### PR TITLE
Add release dates and day counts to Heartbreak patch notes

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -72,90 +72,90 @@
       <summary>Patch Notes</summary>
       <ul>
         <li>
-          Patch notes <strong>1.3.0</strong> - setback to 35%. Added synced logs for Charlie’s supporters.
+          Patch notes <strong>1.3.0</strong> - Day 29 - August 9, 2025 - setback to 35%. Added synced logs for Charlie’s supporters.
         </li>
         <li>
-          Patch notes <strong>1.2.latest</strong> - retired flavor text “NEW: wrote important no-send letter on a plane and did some intense breakthwork. And a therapy worksheet. 15%->50%. From Anger to Depression! Yay! I'm depressed”
+          Patch notes <strong>1.2.latest</strong> - Day 28 - August 8, 2025 - retired flavor text “NEW: wrote important no-send letter on a plane and did some intense breakthwork. And a therapy worksheet. 15%->50%. From Anger to Depression! Yay! I'm depressed”
         </li>
         <li>
-          Patch notes <strong>1.1.6</strong> - switched patch notes header to the default sans-serif font.
+          Patch notes <strong>1.1.6</strong> - Day 28 - August 8, 2025 - switched patch notes header to the default sans-serif font.
         </li>
         <li>
-          Patch notes <strong>1.1.5</strong> - softened patch notes styling, added spacing, and collapsed notes into a dropdown.
+          Patch notes <strong>1.1.5</strong> - Day 28 - August 8, 2025 - softened patch notes styling, added spacing, and collapsed notes into a dropdown.
         </li>
         <li>
-          Patch notes <strong>1.1.4</strong> - added patch notes.
+          Patch notes <strong>1.1.4</strong> - Day 28 - August 8, 2025 - added patch notes.
         </li>
         <li>
-          Patch notes <strong>1.1.3</strong> - added dark mode toggle to top right.
+          Patch notes <strong>1.1.3</strong> - Day 28 - August 8, 2025 - added dark mode toggle to top right.
         </li>
         <li>
-          Patch notes <strong>1.1.2</strong> - moved the progress control
+          Patch notes <strong>1.1.2</strong> - Day 19 - July 30, 2025 - moved the progress control
           buttons lower on the page to improve spacing.
         </li>
         <li>
-          Patch notes <strong>1.1.1</strong> - repositioned the flavor note and
+          Patch notes <strong>1.1.1</strong> - Day 19 - July 30, 2025 - repositioned the flavor note and
           added a subtle shadow for readability.
         </li>
         <li>
-          Patch notes <strong>1.1.0</strong> - raised baseline healing from 15%
+          Patch notes <strong>1.1.0</strong> - Day 19 - July 30, 2025 - raised baseline healing from 15%
           to 50%, introduced pulsing flavor text, and placed the progress bar
           beneath the mood markers.
         </li>
         <li>
-          Patch notes <strong>1.0.12</strong> - enabled the shuffle button to
+          Patch notes <strong>1.0.12</strong> - Day 17 - July 28, 2025 - enabled the shuffle button to
           choose a random art style.
         </li>
         <li>
-          Patch notes <strong>1.0.11</strong> - increased the healing progress
+          Patch notes <strong>1.0.11</strong> - Day 15 - July 26, 2025 - increased the healing progress
           awarded for each activity.
         </li>
         <li>
-          Patch notes <strong>1.0.10</strong> - refined progress markers and
+          Patch notes <strong>1.0.10</strong> - Day 15 - July 26, 2025 - refined progress markers and
           adjusted title spacing for clarity.
         </li>
         <li>
-          Patch notes <strong>1.0.9</strong> - added vertical phase markers and
+          Patch notes <strong>1.0.9</strong> - Day 15 - July 26, 2025 - added vertical phase markers and
           repositioned the controls.
         </li>
         <li>
-          Patch notes <strong>1.0.8</strong> - introduced buttons for manually
+          Patch notes <strong>1.0.8</strong> - Day 15 - July 26, 2025 - introduced buttons for manually
           adjusting progress.
         </li>
         <li>
-          Patch notes <strong>1.0.7</strong> - calculated the days elapsed since
+          Patch notes <strong>1.0.7</strong> - Day 15 - July 26, 2025 - calculated the days elapsed since
           July 11, 2025.
         </li>
         <li>
-          Patch notes <strong>1.0.6</strong> - added a page header and an
+          Patch notes <strong>1.0.6</strong> - Day 15 - July 26, 2025 - added a page header and an
           explanatory context blurb.
         </li>
         <li>
-          Patch notes <strong>1.0.5</strong> - implemented image shuffling while
+          Patch notes <strong>1.0.5</strong> - Day 15 - July 26, 2025 - implemented image shuffling while
           maintaining stage and style consistency.
         </li>
         <li>
-          Patch notes <strong>1.0.4</strong> - integrated an activity log to
+          Patch notes <strong>1.0.4</strong> - Day 15 - July 26, 2025 - integrated an activity log to
           track actions.
         </li>
         <li>
-          Patch notes <strong>1.0.3</strong> - introduced a dynamic Charlie
+          Patch notes <strong>1.0.3</strong> - Day 15 - July 26, 2025 - introduced a dynamic Charlie
           image system with randomizer and shuffle.
         </li>
         <li>
-          Patch notes <strong>1.0.2</strong> - added an image randomizer with
+          Patch notes <strong>1.0.2</strong> - Day 15 - July 26, 2025 - added an image randomizer with
           prompts and configuration for healing stages.
         </li>
         <li>
-          Patch notes <strong>1.0.1</strong> - added a progress label to display
+          Patch notes <strong>1.0.1</strong> - Day 15 - July 26, 2025 - added a progress label to display
           the current healing percentage.
         </li>
         <li>
-          Patch notes <strong>1.0.0</strong> - established the heartbreak
+          Patch notes <strong>1.0.0</strong> - Day 15 - July 26, 2025 - established the heartbreak
           healing page with a progress bar and emoji buttons.
         </li>
         <li>
-          Patch notes <strong>0.0.0</strong> - created the initial page
+          Patch notes <strong>0.0.0</strong> - Day 15 - July 26, 2025 - created the initial page
           framework without information.
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- show days since breakup and release dates for each Heartbreak patch note entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68977cf375e08332b827aa6e6a0255eb