### PR TITLE
Heartbreak: show publish time from latest commit

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -122,6 +122,9 @@
       <summary>Patch Notes</summary>
       <ul>
         <li>
+          Patch notes <strong>1.3.2.2</strong> - Day 29 - August 9, 2025 - “Last published” footer now derives from the latest commit timestamp at build time.
+        </li>
+        <li>
           Patch notes <strong>1.3.2.1</strong> - Day 29 - August 9, 2025 - debugging CORS console noise; added network shim to block external registry calls.
         </li>
         <li>
@@ -229,6 +232,6 @@
       </ul>
     </details>
 
-    <div id="last-published"></div>
+    <div id="last-published">Last published: __LAST_PUBLISHED__</div>
   </body>
 </html>

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -322,13 +322,6 @@ function initDarkMode() {
   }
 }
 
-function setLastPublished() {
-  const el = document.getElementById('last-published');
-  if (!el) return;
-  const now = new Date();
-  el.textContent = `Last published: ${now.toLocaleDateString(undefined, { month: 'numeric', day: 'numeric', year: 'numeric' })}, ${now.toLocaleTimeString()}`;
-}
-
 document.addEventListener('DOMContentLoaded', () => {
   updateProgress();
   updateDaysSinceBreakup();
@@ -337,5 +330,4 @@ document.addEventListener('DOMContentLoaded', () => {
   syncLogs();
   setInterval(syncLogs, 5000);
   fetchStats();
-  setLastPublished();
 });

--- a/heartbreak/update-last-published.js
+++ b/heartbreak/update-last-published.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// find latest commit touching the heartbreak directory
+const commitIso = execSync('git log -1 --format=%cI -- heartbreak', { encoding: 'utf8' }).trim();
+const commitDate = new Date(commitIso);
+const dateStr = commitDate.toLocaleDateString(undefined, { month: 'numeric', day: 'numeric', year: 'numeric' });
+const timeStr = commitDate.toLocaleTimeString();
+
+const indexPath = path.join(__dirname, 'index.html');
+let html = fs.readFileSync(indexPath, 'utf8');
+html = html.replace('Last published: __LAST_PUBLISHED__', `Last published: ${dateStr}, ${timeStr}`);
+fs.writeFileSync(indexPath, html);


### PR DESCRIPTION
## Summary
- derive "Last published" footer from newest GitHub commit
- avoid runtime fetch by updating footer text during build
- document the change in patch notes

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check heartbreak/script.js`
- `node --check heartbreak/update-last-published.js`


------
https://chatgpt.com/codex/tasks/task_e_68980a9c603083329c25a1042bab0e8a