### PR TITLE
Heartbreak log tidy + PST last published

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -122,6 +122,9 @@
       <summary>Patch Notes</summary>
       <ul>
         <li>
+          Patch notes <strong>1.3.2.3</strong> - Day 29 - August 9, 2025 - simplified log location display with spoiler IP and set “Last published” to Pacific time.
+        </li>
+        <li>
           Patch notes <strong>1.3.2.2</strong> - Day 29 - August 9, 2025 - “Last published” footer now derives from the latest commit timestamp at build time.
         </li>
         <li>
@@ -232,6 +235,6 @@
       </ul>
     </details>
 
-    <div id="last-published">Last published: 8/10/2025, 3:36:56 AM</div>
+    <div id="last-published">Last published: 8/9/2025, 9:22:03 PM</div>
   </body>
 </html>

--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -64,10 +64,31 @@ function renderLogs(entries) {
     const div = document.createElement('div');
     div.className = 'entry';
     const ts = new Date(entry.timestamp).toLocaleString();
-    const loc = entry.location
-      ? ` ${entry.location.country || ''}${entry.location.region ? ', ' + entry.location.region : ''}${entry.location.city ? ', ' + entry.location.city : ''}`
-      : '';
-    div.textContent = `[${entry.ip || 'local'}] [${ts}]${loc ? ' [' + loc.trim() + ']' : ''} ${entry.event}`;
+    const ip = entry.ip || 'local';
+    const locParts = [];
+    if (entry.location) {
+      if (entry.location.city) locParts.push(entry.location.city);
+      if (entry.location.region) locParts.push(entry.location.region);
+      if (entry.location.country) locParts.push(entry.location.country);
+    }
+    const loc = locParts.join(', ');
+
+    div.textContent = `[${ts}] `;
+    if (loc) {
+      const details = document.createElement('details');
+      details.className = 'log-location';
+      const summary = document.createElement('summary');
+      summary.textContent = `[${loc}]`;
+      const ipDiv = document.createElement('div');
+      ipDiv.textContent = ip;
+      details.appendChild(summary);
+      details.appendChild(ipDiv);
+      div.appendChild(details);
+      div.appendChild(document.createTextNode(' '));
+    } else {
+      div.appendChild(document.createTextNode(`[${ip}] `));
+    }
+    div.appendChild(document.createTextNode(entry.event));
     logEl.appendChild(div);
   });
 }

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -287,6 +287,20 @@ h1#title {
   font-size: 0.9rem;
 }
 
+.log-location {
+  display: inline;
+}
+
+.log-location > summary {
+  display: inline;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.log-location > summary::-webkit-details-marker {
+  display: none;
+}
+
 #patch-notes {
   margin-top: 2rem;
   width: 100%;

--- a/heartbreak/update-last-published.js
+++ b/heartbreak/update-last-published.js
@@ -6,8 +6,14 @@ const path = require('path');
 // find timestamp of the latest commit in the repository
 const commitIso = execSync('git log -1 --format=%cI', { encoding: 'utf8' }).trim();
 const commitDate = new Date(commitIso);
-const dateStr = commitDate.toLocaleDateString(undefined, { month: 'numeric', day: 'numeric', year: 'numeric' });
-const timeStr = commitDate.toLocaleTimeString();
+const zone = { timeZone: 'America/Los_Angeles' };
+const dateStr = commitDate.toLocaleDateString('en-US', {
+  ...zone,
+  month: 'numeric',
+  day: 'numeric',
+  year: 'numeric'
+});
+const timeStr = commitDate.toLocaleTimeString('en-US', zone);
 
 const indexPath = path.join(__dirname, 'index.html');
 let html = fs.readFileSync(indexPath, 'utf8');


### PR DESCRIPTION
## Summary
- Simplify activity log entries to show location with reveal-on-click IP
- Set "Last published" timestamp to Pacific time and note the change in patch notes

## Testing
- `node --check heartbreak/script.js`
- `node heartbreak/update-last-published.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68981f5fce448332af2157db81335aa3