### PR TITLE
Fix frontend log location display and hide ip

### DIFF
--- a/heartbreak/script.js
+++ b/heartbreak/script.js
@@ -20,9 +20,6 @@ const LOCAL_DAILY_KEY = 'hb-local-daily-stats';
 const GEO_CACHE_KEY = 'hb-geo-cache';
 const GEO_CACHE_TTL_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
 
-// Cache IP lookups so we don't repeatedly query the geo service
-const locationCache = {};
-
 function loadLocalStats() {
   try {
     return JSON.parse(localStorage.getItem(LOCAL_STATS_KEY)) || {
@@ -109,27 +106,59 @@ function saveLocalLogs(logs) {
   } catch (_) {}
 }
 
-function populateLocation(ip, span) {
-  if (!ip || ip === 'local') return;
-  if (locationCache[ip]) {
-    span.textContent = `[${locationCache[ip]}] `;
-    return;
+// ------- Frontend IP geolocation (cached) -------
+function loadGeoCache() {
+  try {
+    return JSON.parse(localStorage.getItem(GEO_CACHE_KEY)) || {};
+  } catch (_) {
+    return {};
   }
-  fetch(`https://ipapi.co/${ip}/json/`)
-    .then(r => (r.ok ? r.json() : null))
-    .then(data => {
-      if (!data) return;
-      const parts = [];
-      if (data.city) parts.push(data.city);
-      if (data.region) parts.push(data.region);
-      if (data.country_name) parts.push(data.country_name);
-      const loc = parts.join(', ');
-      if (loc) {
-        locationCache[ip] = loc;
-        span.textContent = `[${loc}] `;
-      }
-    })
-    .catch(() => {});
+}
+
+function saveGeoCache(cache) {
+  try { localStorage.setItem(GEO_CACHE_KEY, JSON.stringify(cache)); } catch (_) {}
+}
+
+function isLocalIp(ip) {
+  return !ip || ip === 'local' || ip === '127.0.0.1' || ip === '::1';
+}
+
+async function fetchGeoForIp(ip) {
+  if (isLocalIp(ip)) return null;
+  try {
+    const res = await fetch(`https://ipapi.co/${encodeURIComponent(ip)}/json/`, { cache: 'force-cache' });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      city: data.city || null,
+      region: data.region || data.region_code || null,
+      country: data.country_name || data.country || null
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
+async function getLocationForIp(ip) {
+  const cache = loadGeoCache();
+  const now = Date.now();
+  const cached = cache[ip];
+  if (cached && (now - cached.cachedAt) < GEO_CACHE_TTL_MS) {
+    return cached.location || null;
+  }
+  const loc = await fetchGeoForIp(ip);
+  cache[ip] = { cachedAt: now, location: loc };
+  saveGeoCache(cache);
+  return loc;
+}
+
+function formatLocation(loc) {
+  if (!loc) return '';
+  const parts = [];
+  if (loc.city) parts.push(loc.city);
+  if (loc.region) parts.push(loc.region);
+  if (loc.country) parts.push(loc.country);
+  return parts.join(', ');
 }
 
 function renderLogs(entries) {
@@ -141,38 +170,39 @@ function renderLogs(entries) {
   merged.slice().reverse().forEach(entry => {
     const div = document.createElement('div');
     div.className = 'entry';
-    const key = buildEntryKey(entry);
-    div.dataset.key = key;
 
     const ts = new Date(entry.timestamp).toLocaleString();
     const ip = entry.ip || 'local';
 
-    div.textContent = `[${ts}] `;
+    div.appendChild(document.createTextNode(`[${ts}] `));
 
     const locSpan = document.createElement('span');
-    locSpan.className = 'log-location';
+    locSpan.className = 'log-loc';
+    const locText = formatLocation(entry.location);
+    if (locText) {
+      locSpan.textContent = `[${locText}] `;
+    }
     div.appendChild(locSpan);
 
     div.appendChild(document.createTextNode(entry.event));
 
     const ipSpan = document.createElement('span');
-    ipSpan.className = 'log-ip';
+    ipSpan.className = 'spoiler ip-spoiler';
+    ipSpan.setAttribute('role', 'button');
+    ipSpan.setAttribute('tabindex', '0');
+    ipSpan.setAttribute('aria-label', 'Reveal IP');
     ipSpan.textContent = ` [${ip}]`;
+    function toggleReveal() { ipSpan.classList.toggle('revealed'); }
+    ipSpan.addEventListener('click', toggleReveal);
+    ipSpan.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        toggleReveal();
+      }
+    });
     div.appendChild(ipSpan);
 
     logEl.appendChild(div);
-
-    const locParts = [];
-    if (entry.location) {
-      if (entry.location.city) locParts.push(entry.location.city);
-      if (entry.location.region) locParts.push(entry.location.region);
-      if (entry.location.country) locParts.push(entry.location.country);
-    }
-    if (locParts.length) {
-      locSpan.textContent = `[${locParts.join(', ')}] `;
-    } else {
-      populateLocation(ip, locSpan);
-    }
   });
 
   // Populate missing locations asynchronously via frontend geolocation
@@ -181,15 +211,14 @@ function renderLogs(entries) {
 
 async function populateMissingLocations(entries) {
   const nodes = Array.from(document.querySelectorAll('#log .entry'));
-  const nodeByKey = new Map(nodes.map(n => [n.dataset.key, n]));
 
   const tasks = [];
-  for (const entry of entries) {
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
     const ip = entry.ip || 'local';
-    const hasLoc = !!formatLocation(entry.location);
+    const hasLoc = !!(entry.location && (entry.location.city || entry.location.region || entry.location.country));
     if (hasLoc || isLocalIp(ip)) continue;
-    const key = buildEntryKey(entry);
-    const node = nodeByKey.get(key);
+    const node = nodes[nodes.length - 1 - i];
     if (!node) continue;
     tasks.push(
       getLocationForIp(ip).then(loc => {

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -316,6 +316,26 @@ h1#title {
   display: none;
 }
 
+/* Spoiler styling for IP to reduce clutter */
+.spoiler {
+  margin-left: 6px;
+  background: currentColor;
+  color: transparent;
+  border-radius: 3px;
+  padding: 0 4px;
+  cursor: pointer;
+  user-select: none;
+}
+.spoiler::selection { color: transparent; }
+.spoiler.revealed {
+  background: transparent;
+  color: inherit;
+}
+.spoiler:focus { outline: 1px dashed currentColor; outline-offset: 2px; }
+
+/* optional target for loc text */
+.log-loc { white-space: nowrap; }
+
 #patch-notes {
   margin-top: 2rem;
   width: 100%;


### PR DESCRIPTION
Implement frontend IP geolocation and spoiler IP addresses in logs to show location without database storage and reduce clutter.

---
<a href="https://cursor.com/background-agent?bcId=bc-d033cb93-5643-4a72-a7e6-0751fa4ad152">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d033cb93-5643-4a72-a7e6-0751fa4ad152">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

