### PR TITLE
feat: geolocate logs on frontend

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -125,6 +125,9 @@
       <summary>Patch Notes</summary>
       <ul>
         <li>
+          Patch notes <strong>1.4.0.1</strong> - Day 30 - August 10, 2025 - frontend IP geolocation for logs with spoilered IP addresses.
+        </li>
+        <li>
           Patch notes <strong>1.4.0</strong> - Day 30 - August 10, 2025 - added "Valuable lessons" floating bubbles, lessons source file, PWA with offline precache, and expanded Stats (Today & Total) including Shuffle Charlie and Valuable Lessons button presses.
         </li>
         <li>

--- a/heartbreak/styles.css
+++ b/heartbreak/styles.css
@@ -303,17 +303,19 @@ h1#title {
 }
 
 .log-location {
-  display: inline;
+  margin-right: 0.25rem;
 }
 
-.log-location > summary {
-  display: inline;
-  cursor: pointer;
-  text-decoration: underline;
+.log-ip {
+  margin-left: 0.25rem;
+  background-color: #000;
+  color: #000;
+  border-radius: 2px;
+  padding: 0 2px;
 }
 
-.log-location > summary::-webkit-details-marker {
-  display: none;
+.log-ip:hover {
+  color: #fff;
 }
 
 #patch-notes {


### PR DESCRIPTION
## Summary
- fetch viewer location on the frontend for each log entry
- hide raw IPs behind a spoiler in the log list
- stop storing location info in the log server and note the change in patch notes

## Testing
- `node --check heartbreak/script.js`
- `node --check heartbreak/backend/index.js`
- `cd heartbreak/backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898b8edcfcc83329b7154b918df78e4