### PR TITLE
Update flavor note and patch notes for Aug 29

### DIFF
--- a/heartbreak/index.html
+++ b/heartbreak/index.html
@@ -61,7 +61,7 @@
 </head>
 <body>
   <button id="mode-toggle" aria-label="Toggle dark mode">💡</button>
-  <div id="flavor-note">NEW Aug 9: week of vacation and family reunion brought up a lot of old fond memories and I took some steps back 50->35% my therapist says grief is not a linear process which SUCKS</div>
+  <div id="flavor-note">NEW Aug 29: have cried myself to sleep several days over the last couple weeks. Back to depression? 35->45%</div>
   <h1 id="title">Charlie's Heartbreak Healing Progress</h1>
   <p id="project-blurb">Charlie broke up with his partner on July 11, 2025, <span id="days-since"></span> days ago. Track how he's doing by checking in on this page. Press buttons to suggest what he should do to keep on healing. Look at images highly representative of his current mood and state. Text him how to improve this project.</p>
   <div id="progress-wrapper">
@@ -124,6 +124,9 @@
     <details id="patch-notes">
       <summary>Patch Notes</summary>
       <ul>
+        <li>
+          Patch notes <strong>1.4.3.2</strong> - Day 49 - August 29, 2025 - retired flavor text “NEW Aug 9: week of vacation and family reunion brought up a lot of old fond memories and I took some steps back 50->35% my therapist says grief is not a linear process which SUCKS” and replaced with “NEW Aug 29: have cried myself to sleep several days over the last couple weeks. Back to depression? 35->45%”.
+        </li>
         <li>
           Patch notes <strong>1.4.3.1</strong> - Day 44 - August 24, 2025 - simplified therapy button label.
         </li>
@@ -269,6 +272,6 @@
       <div id="meaning-votes" style="display:none;margin-top:6px;font-size:0.85rem;color:#666;"></div>
     </div>
 
-    <div id="last-published">Last published: 8/10/2025, 8:33:22 AM</div>
+    <div id="last-published">Last published: 8/29/2025, 3:42:39 AM</div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace flavor text with new Aug 29 entry and note shift back to depression
- log prior flavor text in new patch notes 1.4.3.2
- refresh last published timestamp

## Testing
- `node update-last-published.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1835b1f708332af2e6ba4082f4a81